### PR TITLE
Catch AttributeError

### DIFF
--- a/parseratorvariable/predicates.py
+++ b/parseratorvariable/predicates.py
@@ -11,6 +11,8 @@ class PartialIndex(object):
     def preprocess(self, doc):
         try:
             tags, _ = self.tag(doc)
+        except AttributeError:
+            part = ''            
         except TypeError:
             part = ''
         else:


### PR DESCRIPTION
For some reason or other (and for reasons I can't fathom), parseratorvariable throws an AttributeError when using dedupe with a `Name` field type from probablepeople.

This catch allows things to proceed normally.